### PR TITLE
[MOD] 이메일 중복체크 API

### DIFF
--- a/src/main/java/com/example/demo/auth/CustomOAuth2Service.java
+++ b/src/main/java/com/example/demo/auth/CustomOAuth2Service.java
@@ -28,6 +28,12 @@ public class CustomOAuth2Service extends DefaultOAuth2UserService {
     //Oauth 소셜 로그인 후처리 담당 메소드
     //로그인 성공 -> 깃허브로 부터 access token을 받아온거 까지가 파라미터인 userRequest
     //userRequest에 담긴 정보로 깃허브를 통해 회원 프로필을 받아오는게 loadUser 메소드의 역할! -> loadUser가 어디서 호출되는건지,,,,,
+
+    /**
+     * loadUser의 return값인 CustomUserDetail 객체가 Authentication으로 Spring Security Context에 저장된다! -> 세션에 저장된다 생각하면 됨
+     * 따라서, 저장하기 전에 사용자의 정보를 다시 입력받으려면 (회원가입 창에 정보를 넣어두고 거기에 추가 정보를 입력받는것) loadUser 메소드가 return되기 전에 처리해야하는데,,,,,, 이걸 도대체 어케하지
+     * */
+
     @Override
     public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException{
 //        System.out.println("clientRegistration: "+userRequest.getClientRegistration()); // -> registrationId: 어떤 oauth 로그인인지
@@ -36,7 +42,7 @@ public class CustomOAuth2Service extends DefaultOAuth2UserService {
           * 깃헙 로그인 클릭 -> 깃허브의 로그인 창이 뜨고 -> 로그인 성공하고 -> code를 return하고 ->
           *그 code를 oauth library가 받고 -> access token을 요청하고
           *까지가 UserRequest 정보!
-          *이제부터 loadUser를 사용해서 userRequest 정보를 사용해서 회원 프로필을 받아와야 한다
+          *이제부터 loadUser를 사용해서 userRequest 정보를 사용해서 회원 프로필, accessToken을 받아와야 한다
         */
 
 //        System.out.println("getAttributes: "+super.loadUser(userRequest).getAttributes());
@@ -73,6 +79,7 @@ public class CustomOAuth2Service extends DefaultOAuth2UserService {
             user=new User(name,nickname,email,pwd);
             user.updateUserCompany(company);
             user.updateProfileImage(profileUrl);
+            user.setGithubProvider("GITHUB");
             userDetailsService.saveUser(user);
         }else{
             user.updateByGithubLogin(name,nickname,email,profileUrl);
@@ -83,9 +90,9 @@ public class CustomOAuth2Service extends DefaultOAuth2UserService {
         CustomUserDetails customUserDetails=new CustomUserDetails(user);
         customUserDetails.setAttributes(oAuth2User.getAttributes()); // 나중에 여기서 필요 정보 빼가서 쓸 수 있음
 
-        UsernamePasswordAuthenticationToken authToken=new UsernamePasswordAuthenticationToken(email,pwd);
+//        UsernamePasswordAuthenticationToken authToken=new UsernamePasswordAuthenticationToken(email,pwd);
         //Authentication(==CustomUserDetails의 data type이라고 생각하는게 편하다) 을 SecurityContext에 저장 -> 나중에 SecurityContext에서 찾으면 로그인 중인 사용자 찾고, 권한 확인 가능
-        SecurityContextHolder.getContext().setAuthentication(authToken);
+//        SecurityContextHolder.getContext().setAuthentication(authToken);
 
         return customUserDetails;
 

--- a/src/main/java/com/example/demo/auth/CustomUserDetails.java
+++ b/src/main/java/com/example/demo/auth/CustomUserDetails.java
@@ -74,6 +74,6 @@ public class CustomUserDetails implements UserDetails, OAuth2User {
 
     @Override
     public String getName() {
-        return user.getUserName();
+        return null;
     }
 }

--- a/src/main/java/com/example/demo/auth/UserDetailsServiceImpl.java
+++ b/src/main/java/com/example/demo/auth/UserDetailsServiceImpl.java
@@ -14,7 +14,6 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Optional;
 
 
 @Service
@@ -38,10 +37,12 @@ public class UserDetailsServiceImpl implements UserDetailsService {
 
     public String checkEmailValidate(String email){
         User user=userRepository.findByUserEmail(email);
-        if(user!=null){
-            return "email conflict";
+        if(user==null){
+            return "email valid";
+        }else if(user.getLoginProvider()!=null&&user.getLoginProvider().equals("GITHUB")){
+            return "email github";
         }else{
-            return "email validate";
+            return "email conflict";
         }
     }
 
@@ -50,7 +51,7 @@ public class UserDetailsServiceImpl implements UserDetailsService {
         if(user!=null){
             return "nickname conflict";
         }else{
-            return "nickname validate";
+            return "nickname valid";
         }
     }
 
@@ -78,6 +79,10 @@ public class UserDetailsServiceImpl implements UserDetailsService {
     public String updateUserByGithub(User updateUser){
         userRepository.save(updateUser);
         return "success";
+    }
+
+    private boolean checkIfGithub(String provider){
+        return provider.equals("GITHUB");
     }
 
     @Override

--- a/src/main/java/com/example/demo/controller/UserController.java
+++ b/src/main/java/com/example/demo/controller/UserController.java
@@ -10,13 +10,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.web.bind.annotation.*;
-
-import java.security.Security;
-import java.util.Collection;
 
 @RestController
 public class UserController {
@@ -32,11 +29,6 @@ public class UserController {
 
     @PostMapping("/signup")
     public String test(@RequestBody SignupVO signupVO){
-//        HashMap<String, Object> params
-//        System.out.println("params = " + params);
-//        String name=(String) params.get("name");
-//        String nickname=(String) params.get("nickname");
-//        String email=(String) params.get("email");
         String pwd= signupVO.getPassword();
         String encodedPwd=bCryptPasswordEncoder.encode(pwd);
         String imgUrl=signupVO.getImageUrl();
@@ -72,6 +64,7 @@ public class UserController {
         return new ResponseEntity<>(new ResponseMessage(409,"이미 사용중인 닉네임"), HttpStatus.CONFLICT);
     }
 
+
     @PostMapping("/signin")
     public ResponseEntity<ResponseMessage> signin(@RequestBody SigninVO signinVO){
         String email=signinVO.getEmail();
@@ -99,17 +92,9 @@ public class UserController {
     }
 
     @GetMapping("/review")
-    public String test(){
+    public ResponseEntity<ResponseMessage> test(@AuthenticationPrincipal CustomUserDetails customUserDetails){
         //로그인 상태 유지 확인 테스트 성공
-        Object principal=SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-        CustomUserDetails userDetails=(CustomUserDetails) principal;
-        String username = userDetails.getUsername();
-        System.out.println("email = " + username); // email이 반환됨
-        User user=userDetails.getUser();
-        String nickname=user.getUserNickname();
-        String imageUrl=user.getUserProfileImg();
-        System.out.println("nickname = " + nickname);
-        System.out.println("imageUrl = " + imageUrl);
-        return "success";
+        User user=customUserDetails.getUser();
+        return new ResponseEntity<>(ResponseMessage.withData(200, "로그인 성공", user),HttpStatus.OK);
     }
 }

--- a/src/main/java/com/example/demo/controller/UserController.java
+++ b/src/main/java/com/example/demo/controller/UserController.java
@@ -50,19 +50,23 @@ public class UserController {
         return "signup success";
     }
 
-    @GetMapping("/signup")
-    public  ResponseEntity<ResponseMessage> emailCheck(@RequestParam("email") String email){
+    @GetMapping("/signup/{email:.+}/")
+    public  ResponseEntity<ResponseMessage> emailCheck(@PathVariable("email") String email){
+//        System.out.println("email = " + email);
         String valid=userService.checkEmailValidate(email);
-        if(valid.equals("email validate")){
+        if(valid.equals("email valid")){
             return new ResponseEntity<>(new ResponseMessage(200,"이메일 사용가능"), HttpStatus.OK);
+        }else if(valid.equals("email github")){
+            return new ResponseEntity<>(new ResponseMessage(400,"깃허브로 소셜로그인 된 이메일"), HttpStatus.BAD_REQUEST);
+        }else{
+            return new ResponseEntity<>(new ResponseMessage(409,"이미 사용중인 이메일"), HttpStatus.CONFLICT);
         }
-        return new ResponseEntity<>(new ResponseMessage(409,"이미 사용중인 이메일"), HttpStatus.CONFLICT);
     }
 
     @GetMapping("/signup/{nickname}")
     public ResponseEntity<ResponseMessage> nicknameCheck(@PathVariable String nickname){
         String valid=userService.checkNicknameValidate(nickname);
-        if(valid.equals("nickname validate")){
+        if(valid.equals("nickname valid")){
             return new ResponseEntity<>(new ResponseMessage(200,"닉네임 사용가능"), HttpStatus.OK);
         }
         return new ResponseEntity<>(new ResponseMessage(409,"이미 사용중인 닉네임"), HttpStatus.CONFLICT);
@@ -76,11 +80,13 @@ public class UserController {
 //        System.out.println("authentication: "+auth.getPrincipal());
         if(auth!=null){
             //login success
+            //User 정보 빼오는 부분 중복 코드 없애기
             SecurityContextHolder.getContext().setAuthentication(auth);
             //고유값인 이메일, 거기에 매칭되는 pwd로 AuthenticationToken을 만들면 거기에 매칭되는 CustomUserDetails객체 (Authentication type이라 생각하는게 편하다) 를 SecurityContext에 저장한다!
-            Object principal=SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+            CustomUserDetails principal=(CustomUserDetails) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+            User user=principal.getUser();
             //SecurityContext에 Authentication 정보 저장
-            return new ResponseEntity<>(ResponseMessage.withData(200, "로그인 성공", principal),HttpStatus.OK);
+            return new ResponseEntity<>(ResponseMessage.withData(200, "로그인 성공", user),HttpStatus.OK);
         }
 
         return new ResponseEntity<>(new ResponseMessage(401,"로그인 실패"),HttpStatus.UNAUTHORIZED);
@@ -89,7 +95,7 @@ public class UserController {
 
     @GetMapping("/")
     public String landing(){
-    return "landing page";
+        return "landing page";
     }
 
     @GetMapping("/review")

--- a/src/main/java/com/example/demo/domain/User.java
+++ b/src/main/java/com/example/demo/domain/User.java
@@ -49,6 +49,9 @@ public class User {
     @NotNull
     private String role;
 
+    @Column
+    private String loginProvider;
+
     @Builder
     public User(String name, String nickname, String email, String pwd){
         this.userName=name;
@@ -77,6 +80,10 @@ public class User {
         this.userNickname=nickname;
         this.userEmail=email;
         this.userProfileImg=profileUrl;
+    }
+
+    public void setGithubProvider(String provider){
+        this.loginProvider=provider;
     }
 
     // 소속인증 (userCompany) 은 처음 User 데이터 생성 시에 들어가는 걊이 아니므로 생략


### PR DESCRIPTION
1. `host:8080/signup/{email}/ `로 API 변경
    **맨 뒤에 / 를 붙여주어야 제대로 이메일로 인식**
2. 깃허브 소셜 로그인 된 계정 -> 회원가입  시 "깃허브로 소셜 로그인 된 계정" msg 추가

- fixed #2 