### PR TITLE
[FIX] 깃허브 소셜로그인 무한 요청 해결

### DIFF
--- a/src/main/java/com/example/demo/auth/CustomOAuth2Service.java
+++ b/src/main/java/com/example/demo/auth/CustomOAuth2Service.java
@@ -1,9 +1,6 @@
 package com.example.demo.auth;
 
 import com.example.demo.domain.User;
-import org.springframework.security.authentication.InternalAuthenticationServiceException;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
@@ -11,6 +8,7 @@ import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
 
+import javax.servlet.http.HttpSession;
 import java.util.Map;
 
 @Service
@@ -18,10 +16,12 @@ import java.util.Map;
 public class CustomOAuth2Service extends DefaultOAuth2UserService {
     private final UserDetailsServiceImpl userDetailsService;
     private final BCryptPasswordEncoder bCryptPasswordEncoder;
+    private final HttpSession httpSession;
 
-    public CustomOAuth2Service(UserDetailsServiceImpl userDetailsService, BCryptPasswordEncoder bCryptPasswordEncoder) {
+    public CustomOAuth2Service(UserDetailsServiceImpl userDetailsService, BCryptPasswordEncoder bCryptPasswordEncoder, HttpSession httpSession) {
         this.userDetailsService = userDetailsService;
         this.bCryptPasswordEncoder = bCryptPasswordEncoder;
+        this.httpSession = httpSession;
     }
 
 
@@ -95,9 +95,9 @@ public class CustomOAuth2Service extends DefaultOAuth2UserService {
         CustomUserDetails customUserDetails=new CustomUserDetails(user);
         customUserDetails.setAttributes(oAuth2User.getAttributes()); // 나중에 여기서 필요 정보 빼가서 쓸 수 있음
 
-//        UsernamePasswordAuthenticationToken authToken=new UsernamePasswordAuthenticationToken(email,pwd);
-        //Authentication(==CustomUserDetails의 data type이라고 생각하는게 편하다) 을 SecurityContext에 저장 -> 나중에 SecurityContext에서 찾으면 로그인 중인 사용자 찾고, 권한 확인 가능
-//        SecurityContextHolder.getContext().setAuthentication(authToken);
+        httpSession.setAttribute("user",user); // /nickname에서 방금 로그인 한 사용자 정보 찾기 위해
+        httpSession.setAttribute("nodeId",nodeId);
+
 
         return customUserDetails;
 

--- a/src/main/java/com/example/demo/auth/WebSecurityConfig.java
+++ b/src/main/java/com/example/demo/auth/WebSecurityConfig.java
@@ -48,7 +48,7 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter { // 스프�
                 .and()
                 .authorizeRequests()
                 .mvcMatchers(HttpMethod.OPTIONS, "/**").permitAll() // Preflight Request 허용해주기
-                .antMatchers("/","/**/*.png","/**/*.jpg","/**/*.js","/**/*.css","/**/*.html","/**/*.gif","/**/*.svg","/signup","/signup/**","/signin","/oauth2/**").permitAll()
+                .antMatchers("/","/**/*.png","/**/*.jpg","/**/*.js","/**/*.css","/**/*.html","/**/*.gif","/**/*.svg","/signup","/signup/**","/signin","/oauth2/**","/nickname","/login/**").permitAll()
                 .antMatchers(HttpMethod.GET,"/lectures","/lectures/**","/studies","/studies/**","/roadmaps","/roadmaps/**").permitAll()
                 .antMatchers(HttpMethod.PATCH,"/lectures/**").hasRole("ADMIN") // ADMIN이라고 작성하면 자동으로 ROLE_ADMIN으로 검색이 이루어진다
                 .antMatchers(HttpMethod.DELETE,"/lectures/**").hasRole("ADMIN") //ADMIN 권한을 가진 경우에만 접근 허용
@@ -59,7 +59,7 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter { // 스프�
                 .and()
                 .oauth2Login().userInfoEndpoint().userService(customOAuth2UserService)
                 .and()
-                .defaultSuccessUrl("/temp-login-success",true) // 추후 url 변경 (localhost:3000/프론트라우터)
+                .defaultSuccessUrl("/nickname",true) // GetMapping의 /nickname으로 가서 깃허브 유저네임 중복 체크!
                 .and()
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
                 .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS);

--- a/src/main/java/com/example/demo/controller/UserController.java
+++ b/src/main/java/com/example/demo/controller/UserController.java
@@ -15,6 +15,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.web.bind.annotation.*;
 
+import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 import java.io.IOException;
@@ -107,7 +108,7 @@ public class UserController {
     }
 
     @GetMapping("/temp-login-success")
-    public ResponseEntity<ResponseMessage> test(HttpServletResponse response) throws IOException{
+    public ResponseEntity<ResponseMessage> test(HttpServletResponse response) {
 
 
         //로그인 상태 유지 확인 테스트 성공
@@ -117,33 +118,31 @@ public class UserController {
 
     // 깃허브 회원가입시 닉네임 중복을 체크하는 API -> 프론트에서 해당 라우터가 완성되면 동작하도록 해당 api를 호출하는 코드는 주석처리 해둠
     @GetMapping("/nickname")
-    public ResponseEntity<String> checkGithubJoinNicknameConflict(@AuthenticationPrincipal CustomUserDetails customUserDetails) throws IOException, URISyntaxException {
-        //SecurityContext에 User 정보가 저장된 후 여기로 넘어오는 것임
-        Long savedUserId=customUserDetails.getUser().getUserId(); // 방금 깃허브 회원가입으로 인해 저장된 User의 계정
-        User user=userService.findUserById(savedUserId);
+    public void checkGithubJoinNicknameConflict(HttpServletRequest request,HttpServletResponse response) throws IOException {
+
+        User user=(User)request.getSession().getAttribute("user");
+        Long savedUserId=user.getUserId();
+        String nodeId=(String)request.getSession().getAttribute("nodeId");
 
         String userNickname=user.getUserNickname();
-        String redirect_uri="http://localhost:3000"; // http://localhost:3000/{react route} -> 로그인 후 디폴트 페이지가 들어감
-        HttpHeaders httpHeaders=new HttpHeaders();
+        String redirect_uri="http://localhost:3000"; // http://localhost:3000/{react route}
+
         if(userNickname.contains("_CONFLICT")){
             //중복 닉네임이 있는 유저라는 의미이므로, 새로운 닉네임 폼으로 보내주어야 한다
             redirect_uri+="/nickname/"+savedUserId; // 닉네임폼(프론트에서 제작한)
-            httpHeaders.setLocation(new URI(redirect_uri));
             System.out.println("github join, conflicted nickname! Redirect: "+redirect_uri);
-//            response.sendRedirect(redirect_uri);
-            return new ResponseEntity<>("nickname reset needed",httpHeaders,HttpStatus.OK);
+            response.sendRedirect(redirect_uri);
+
             // 프론트에서 닉네임입력폼을 /nickname/{userId}로 라우팅 해놓았다면, 여기로 redirect 요청을 보냈을 때 해당 페이지가 띄워지는가 (즉 스프링에서 리액트의 router에 요청을 보낼 수 있는가)
             //이후 프론트의 닉네임폼에서 닉네임을 새롭게 입력하고 -> /signup/{userId}/{nickname} 으로 GET 요청
         }else{
             //닉네임이 정상인 회원 (자체 회원가입 or 깃허브 username 중복없는 새 회원 or 깃허브 이미 등록 -> 이번에 로그인한 회원)
             //그냥 로그인 후 페이지로 자동 redirect
-            String jwtToken=userService.authenticateLogin(user.getUserEmail(),null);
-            redirect_uri+="/landing";
-            httpHeaders.setLocation(new URI(redirect_uri));
-//            redirect_uri+="/main"; // 프론트에서 설정한 로그인 후 첫 페이지
+            String jwtToken=userService.authenticateLogin(user.getUserEmail(),nodeId);
+            redirect_uri+="/github-login/"+jwtToken; // token 암호화 추가
             System.out.println("not a conflicted nickname, Redirect: "+redirect_uri);
-//            response.sendRedirect(redirect_uri);
-            return new ResponseEntity<>(jwtToken,httpHeaders,HttpStatus.OK); //토큰 string, 헤더에는 목적지 프론트 라우터, status 200
+            response.sendRedirect(redirect_uri);
+
         }
         //중복 닉네임이면 닉네임에 username_CONFLICT를 저장
         //프론트에서 fetch를 통해 Response 받아올 수 있음


### PR DESCRIPTION
1. 깃허브 소셜 로그인 시 토큰 발행 안되고 인증 무한 요청하던 문제 해결
2. ResponseBody로 redirect 안됨 -> path variable을 사용한 react로의 redirect로 해결
3. path variable로 jwtToken 보내는 부분 암호화 추가할 예정

**!전달사항! 아직 프론트의 라우터가 완성되지 않은 상태이므로 깃허브 소셜로그인은 사용해도 redirect가 안돼서 제대로 돌아가지 않습니다. **